### PR TITLE
Fix proxy_use_auth variable name

### DIFF
--- a/1.2/config.php
+++ b/1.2/config.php
@@ -65,10 +65,10 @@ $proxy_use_auth = getenv('PROXY_USEAUTH');                 # Enable/Disable Prox
  */
 $proxy_auth     = base64_encode("$proxy_user:$proxy_pass");
 
-if ($proxy_enabled == true && proxy_use_auth == false) {
+if ($proxy_enabled == true && $proxy_use_auth == false) {
     stream_context_set_default(['http'=>['proxy'=>'tcp://$proxy_server:$proxy_port']]);
 }
-elseif ($proxy_enabled == true && proxy_use_auth == true) {
+elseif ($proxy_enabled == true && $proxy_use_auth == true) {
     stream_context_set_default(
         array('http' => array(
               'proxy' => "tcp://$proxy_server:$proxy_port",
@@ -76,6 +76,4 @@ elseif ($proxy_enabled == true && proxy_use_auth == true) {
               'header' => "Proxy-Authorization: Basic $proxy_auth"
         )));
 }
-
-?>
 


### PR DESCRIPTION
This stops config.php printing a warning and multiple blank lines at the start of every page. This change fixes subnet scanning.